### PR TITLE
Add Token caching

### DIFF
--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -78,7 +78,11 @@ class Agent:
             if agent_initiated_restart:
                 conversation.append({
                     "role": "user",
-                    "content": "The program has restarted and is continuing execution automatically. Please continue from where you left off."
+                    "content": [{
+                        "type": "text",
+                        "text": "The program has restarted and is continuing execution automatically. Please continue from where you left off.",
+                        "cache_control": {"type": "ephemeral"}
+                    }]
                 })
                 self.read_user_input = False
         else:
@@ -134,7 +138,8 @@ class Agent:
                             "id": b.id,
                             "name": b.name,
                             "input": b.input
-                        })
+                        }),
+                        "cache_control": {"type": "ephemeral"}
                     }
                     for b in response.content
                 ]

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -1,3 +1,24 @@
+import json
+
+
+def remove_all_but_last_three_cache_controls(conversation):
+    number_of_cache_controls = 3
+    cache_control = """, \"cache_control\": {\"type\": \"ephemeral\"}"""
+    parts = json.dumps(conversation).split(cache_control)
+    print(parts)
+    count = len(parts) - 1  # number of occurrences
+    print(count)
+
+    if count <= number_of_cache_controls:
+        return conversation  # Nothing to remove
+
+    # Join: keep the target only for the last n occurrences
+    # The first (count - n) splits won't get the target re-inserted
+    first_part = ''.join(parts[:count - number_of_cache_controls + 1])
+    last_part = cache_control.join(parts[count - number_of_cache_controls + 1:])
+    return json.loads(first_part + last_part)
+
+
 def run_inference(conversation, llm_client, tools, consecutive_tool_count, max_consecutive_tools=10):
     tools_param = []
     for t in tools:
@@ -20,6 +41,8 @@ def run_inference(conversation, llm_client, tools, consecutive_tool_count, max_c
                 "name": "ask_human"
             }
             # We'll reset the counter when ask_human is actually executed
+
+    conversation = remove_all_but_last_three_cache_controls(conversation)
 
     return llm_client.messages.create(
         model="claude-sonnet-4-20250514",

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -5,9 +5,7 @@ def remove_all_but_last_three_cache_controls(conversation):
     number_of_cache_controls = 3
     cache_control = """, \"cache_control\": {\"type\": \"ephemeral\"}"""
     parts = json.dumps(conversation).split(cache_control)
-    print(parts)
     count = len(parts) - 1  # number of occurrences
-    print(count)
 
     if count <= number_of_cache_controls:
         return conversation  # Nothing to remove


### PR DESCRIPTION
Adds token caching via cache control. Controls number of cache control properties because the max is 4 and the Claude API  throws errors if more than 4 exist in the requests.
Checked that caching works via Anthropic Console Logs tab.

Link to the Cache Control Docs: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching